### PR TITLE
Add constructors for DockerImageName

### DIFF
--- a/src/main/java/com/dajudge/kindcontainer/ApiServerContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/ApiServerContainer.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.shaded.com.google.common.io.Files;
 import org.testcontainers.shaded.org.bouncycastle.asn1.x509.GeneralName;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,6 +64,10 @@ public class ApiServerContainer extends GenericContainer<ApiServerContainer> {
     }
 
     public ApiServerContainer(final String apiServerImage) {
+        this(DockerImageName.parse(apiServerImage));
+    }
+
+    public ApiServerContainer(final DockerImageName apiServerImage) {
         super(apiServerImage);
         etcd = new EtcdContainer();
         this

--- a/src/main/java/com/dajudge/kindcontainer/BaseKindContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/BaseKindContainer.java
@@ -31,6 +31,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.shaded.org.yaml.snakeyaml.Yaml;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.IOException;
 import java.util.*;
@@ -69,6 +70,10 @@ public class BaseKindContainer<T extends BaseKindContainer<T>> extends GenericCo
     }
 
     public BaseKindContainer(final String image) {
+        this(DockerImageName.parse(image));
+    }
+
+    public BaseKindContainer(final DockerImageName image) {
         super(image);
         this.withStartupTimeout(ofSeconds(300))
                 .withCreateContainerCmdModifier(cmd -> {

--- a/src/main/java/com/dajudge/kindcontainer/KindContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/KindContainer.java
@@ -16,5 +16,18 @@ limitations under the License.
 
 package com.dajudge.kindcontainer;
 
+import org.testcontainers.utility.DockerImageName;
+
 public class KindContainer extends BaseKindContainer<KindContainer> {
+    public KindContainer() {
+        super();
+    }
+
+    public KindContainer(final String image) {
+        super(image);
+    }
+
+    public KindContainer(final DockerImageName image) {
+        super(image);
+    }
 }


### PR DESCRIPTION
Testcontainers favors constructors using DockerImageName lately. Kindcontainer should align with that.