### PR TITLE
Split kubectl tests into container vs fluent tests

### DIFF
--- a/src/test/java/com/dajudge/kindcontainer/kubectl/KubectlContainerTest.java
+++ b/src/test/java/com/dajudge/kindcontainer/kubectl/KubectlContainerTest.java
@@ -1,0 +1,52 @@
+package com.dajudge.kindcontainer.kubectl;
+
+import com.dajudge.kindcontainer.ApiServerContainer;
+import com.dajudge.kindcontainer.K3sContainer;
+import com.dajudge.kindcontainer.KindContainer;
+import com.dajudge.kindcontainer.KubernetesContainer;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Supplier;
+
+import static io.fabric8.kubernetes.client.Config.fromKubeconfig;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(Parameterized.class)
+public class KubectlContainerTest {
+    @Parameterized.Parameters
+    public static Collection<Supplier<KubernetesContainer<?>>> apiServers() {
+        return Arrays.asList(ApiServerContainer::new, K3sContainer::new, KindContainer::new);
+    }
+
+    protected final Supplier<KubernetesContainer<?>> k8sFactory;
+
+    public KubectlContainerTest(final Supplier<KubernetesContainer<?>> k8sFactory) {
+        this.k8sFactory = k8sFactory;
+    }
+
+    @Test
+    public void kubectl_works() {
+        try (final KubernetesContainer<?> k8s = createK8s()) {
+            k8s.start();
+            try (final DefaultKubernetesClient client = createClient(k8s)) {
+                assertNotNull(client.inNamespace("my-namespace").serviceAccounts().withName("my-service-account").get());
+            }
+        }
+    }
+
+    @NotNull
+    private DefaultKubernetesClient createClient(KubernetesContainer<?> k8s) {
+        return new DefaultKubernetesClient(fromKubeconfig(k8s.getKubeconfig()));
+    }
+
+    private KubernetesContainer<?> createK8s() {
+        return k8sFactory.get()
+                .withKubectl(kubectl -> kubectl.apply.fileFromClasspath("manifests/serviceaccount1.yaml").run());
+    }
+}

--- a/src/test/java/com/dajudge/kindcontainer/kubectl/KubectlFluentTest.java
+++ b/src/test/java/com/dajudge/kindcontainer/kubectl/KubectlFluentTest.java
@@ -1,5 +1,9 @@
-package com.dajudge.kindcontainer;
+package com.dajudge.kindcontainer.kubectl;
 
+import com.dajudge.kindcontainer.ApiServerContainer;
+import com.dajudge.kindcontainer.K3sContainer;
+import com.dajudge.kindcontainer.KindContainer;
+import com.dajudge.kindcontainer.KubernetesContainer;
 import com.dajudge.kindcontainer.exception.ExecutionException;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
@@ -25,18 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
-@RunWith(Parameterized.class)
-public class KubectlTest {
-    @Parameterized.Parameters
-    public static Collection<Supplier<KubernetesContainer<?>>> apiServers() {
-        return Arrays.asList(ApiServerContainer::new, K3sContainer::new, KindContainer::new);
-    }
-
-    protected final Supplier<KubernetesContainer<?>> k8sFactory;
-
-    public KubectlTest(final Supplier<KubernetesContainer<?>> k8sFactory) {
-        this.k8sFactory = k8sFactory;
-    }
+public class KubectlFluentTest {
 
     @Test
     public void multiple_invocations_work() {
@@ -105,7 +98,7 @@ public class KubectlTest {
             final Function<KubernetesContainer<?>, KubernetesContainer<?>> config,
             final Consumer<KubernetesContainer<?>> consumer
     ) {
-        try (final KubernetesContainer<?> k8s = config.apply(k8sFactory.get())) {
+        try (final KubernetesContainer<?> k8s = config.apply(new ApiServerContainer<>())) {
             k8s.start();
             consumer.accept(k8s);
         }


### PR DESCRIPTION
all kubectl tests are currently run once per container implementation. this makes the tests run unnecessarily long - especially when more kubectl fluent API is added.

they could be split up into
* one parameterized test class that simply tests the general kubectl integration per container with one test
* test classes for the fluent functionality that only operate on an `ApiServerContainer`

This PR does that.