### PR TITLE
Use newer Etcd version

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ by default. These are the images used by Kindcontainer if you don't override the
 |  `ApiServerContainer`   | `registry.k8s.io/kube-apiserver` |   `v${major}.${minor}.${patch}`    |
 |     `K3sContainer`      |          `rancher/k3s`           | `v${major}.${minor}.${patch}-k3s1` |
 |     `KindContainer`     |          `kindest/node`          |   `v${major}.${minor}.${patch}`    |
-|         `etcd`          |      `registry.k8s.io/etcd`      |             `3.4.13-0`             |
+|         `etcd`          |      `registry.k8s.io/etcd`      |             `3.5.12-0`             |
 |    Fluent API `helm`    |          `alpine/helm`           |              `3.14.0`              |
 |  Fluent API `kubectl`   |        `bitnami/kubectl`         |       `1.21.9-debian-10-r10`       |
 |    Webhooks `nginx`     |             `nginx`              |              `1.23.3`              |

--- a/src/main/java/com/dajudge/kindcontainer/ApiServerContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/ApiServerContainer.java
@@ -44,7 +44,7 @@ public class ApiServerContainer<T extends ApiServerContainer<T>> extends Kuberne
     private static final int INTERNAL_API_SERVER_PORT = 6443;
     private final CertAuthority etcdCa = new CertAuthority(System::currentTimeMillis, "CN=etcd CA");
     private final CertAuthority apiServerCa = new CertAuthority(System::currentTimeMillis, "CN=API Server CA");
-    private DockerImageName etcdImage = DockerImageName.parse("registry.k8s.io/etcd:3.4.13-0");
+    private DockerImageName etcdImage = DockerImageName.parse("registry.k8s.io/etcd:3.5.12-0");
     private final KeyStoreWrapper apiServerKeyPair = apiServerCa.newKeyPair("O=system:masters,CN=kubernetes-admin", asList(
             new GeneralName(GeneralName.iPAddress, Utils.resolve(getHost())),
             new GeneralName(GeneralName.dNSName, "localhost"),


### PR DESCRIPTION
When running the `ApiServerContainer` with the default Etcd version 3.4.13 on Arm-based MacOS, it looks like the container registry doesn't serve the multi-arch manifest but serves only the container for `amd64`:

```
[2024-02-21 19:05:42,933] INFO Creating container for image: registry.k8s.io/etcd:3.4.13-0 (tc.registry.k8s.io/etcd:3.4.13-0:390)
[2024-02-21 19:05:43,088] INFO Container registry.k8s.io/etcd:3.4.13-0 is starting: 624c4a64007248aff8f451f551077d2189fd8f51197c48595be352c8fdac089b (tc.registry.k8s.io/etcd:3.4.13-0:454)
[2024-02-21 19:05:43,171] WARN The architecture 'amd64' for image 'registry.k8s.io/etcd:3.4.13-0' (ID sha256:05b738aa1bc6355db8a2ee8639f3631b908286e43f584a3d2ee0c472de033c28) does not match the Docker server architecture 'arm64'. This will cause the container to execute much more slowly due to emulation and may lead to timeout failures. (tc.registry.k8s.io/etcd:3.4.13-0:488)
[2024-02-21 19:05:43,172] INFO Container registry.k8s.io/etcd:3.4.13-0 started in PT0.238978S (tc.registry.k8s.io/etcd:3.4.13-0:544)
```

While that works, it seems suboptimal. This Pr updates the Etcd version used by default to 3.5.12. For this version, the multi-arch images seem to be served properly:

```
[2024-02-21 19:08:38,878] INFO Container registry.k8s.io/etcd:3.5.12-0 is starting: 0f6a5960a168baa4d983d16af245a357794939c5dec6861691f317f376dbb1fc (tc.registry.k8s.io/etcd:3.5.12-0:454)
[2024-02-21 19:08:38,970] INFO Container registry.k8s.io/etcd:3.5.12-0 started in PT0.244075S (tc.registry.k8s.io/etcd:3.5.12-0:544)
```

While I can override the Etcd version when starting the container, this seems like something what might be useful in general?