### PR TITLE
Remove publishing of junit test results

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
         run: ./gradlew build
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
           path: build/test-results/test/*.xml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,29 +45,3 @@ jobs:
         env:
           CONTAINER_FILTER: ${{ matrix.version }}
         run: ./gradlew build
-      - name: Upload Test Results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Test Results
-          path: build/test-results/test/*.xml
-
-  publish-test-results:
-    name: "Publish Tests Results"
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      pull-requests: write
-    if: always()
-
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          junit_files: "artifacts/**/*.xml"


### PR DESCRIPTION
It's not been of much use lately anyway and it's now breaking the build.