### PR TITLE
Enable kubelet feature gates: KubeletInUserNamespace: true

### DIFF
--- a/src/main/resources/kubeadm-1.24.0.yaml
+++ b/src/main/resources/kubeadm-1.24.0.yaml
@@ -52,6 +52,8 @@ nodeRegistration:
     provider-id: kind://docker/kind/kindcontainer-control-plane
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
+featureGates:
+  KubeletInUserNamespace: true
 cgroupDriver: systemd
 cgroupRoot: /kubelet
 evictionHard:

--- a/src/main/resources/kubeadm-1.24.0.yaml
+++ b/src/main/resources/kubeadm-1.24.0.yaml
@@ -52,6 +52,7 @@ nodeRegistration:
     provider-id: kind://docker/kind/kindcontainer-control-plane
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
 featureGates:
   KubeletInUserNamespace: true
 cgroupDriver: systemd
@@ -62,7 +63,6 @@ evictionHard:
   nodefs.inodesFree: 0%
 failSwapOn: false
 imageGCHighThresholdPercent: 100
-kind: KubeletConfiguration
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 conntrack:


### PR DESCRIPTION
- Enable kubelet feature gates: `KubeletInUserNamespace: true` to allow podman rootless to work when we create a kind cluster.
- See #352
- This PR has been tested successfully on macos using podman 5.3.2 rootless or rootfull with the following testing project where we create a kind cluster, deploy Argo CD - https://github.com/ch007m/quarkus-kind-testcontainer/blob/main/src/test/java/org/acme/ArgoCDDeployTest.java