### PR TITLE
Update Java distribution to temurin

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Build with Gradle
         env:
           CONTAINER_FILTER: ${{ matrix.version }}


### PR DESCRIPTION
Replace deprecated 'adopt' distribution with 'temurin'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)