### PR TITLE
Add kubeadm v1beta4 support for Kubernetes 1.36+

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,21 @@
 # AGENTS.md
 
+## Pull request procedure
+
+For every non-trivial PR, treat automated review feedback as part of the normal completion loop rather than as optional follow-up.
+
+After pushing changes:
+
+1. Wait for the initial automated/Codex review to complete.
+2. Read every review finding in context and verify it against the actual code and CI evidence; do not accept a finding blindly just because it is marked high priority.
+3. If a finding is valid, implement the fix in the same PR when appropriate.
+4. Reply to the review thread with a concise explanation of what changed, including any important nuance if the review diagnosis was overstated or contradicted by CI.
+5. Mark the addressed review thread resolved.
+6. Request a fresh Codex review on the updated head.
+7. Repeat until the latest review has no unresolved actionable findings and CI is green, except for failures that are clearly unrelated and already understood/documented.
+
+When CI evidence contradicts a review claim, prefer empirical verification over assumption. For example, confirm that the relevant code path or configuration was actually exercised before dismissing or accepting the finding.
+
 ## Release hygiene
 
 Before preparing a new release, **strongly prefer checking every pinned sidecar/default container image against its upstream current stable release and updating stale images in dedicated PRs**. Do not silently carry obsolete sidecar versions into a new release when a supported update is available.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ After pushing changes:
 
 When CI evidence contradicts a review claim, prefer empirical verification over assumption. For example, confirm that the relevant code path or configuration was actually exercised before dismissing or accepting the finding.
 
+When rebasing or rebuilding an existing PR branch, **do not push intermediate work-in-progress states to the PR branch**. Build and verify the complete rebased result off-branch first, then move/update the PR branch once to the final commit. In particular, never temporarily move the PR head to exactly `master`, because GitHub may automatically close the PR when the head becomes identical to its base. Avoid transient partial states that trigger unnecessary CI, review churn, conflicts, or close/reopen events.
+
 ## Release hygiene
 
 Before preparing a new release, **strongly prefer checking every pinned sidecar/default container image against its upstream current stable release and updating stale images in dedicated PRs**. Do not silently carry obsolete sidecar versions into a new release when a supported update is available.

--- a/src/main/java/com/dajudge/kindcontainer/KindContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/KindContainer.java
@@ -51,6 +51,7 @@ public class KindContainer<T extends KindContainer<T>> extends KubernetesWithKub
     private static final Map<KubernetesVersionDescriptor, String> KUBEADM_CONFIGS = new HashMap<KubernetesVersionDescriptor, String>() {{
         put(new KubernetesVersionDescriptor(1, 21, 0), "kubeadm-1.21.0.yaml");
         put(new KubernetesVersionDescriptor(1, 24, 0), "kubeadm-1.24.0.yaml");
+        put(new KubernetesVersionDescriptor(1, 36, 0), "kubeadm-1.36.0.yaml");
     }};
     private static final String KUBECONFIG_PATH = "/etc/kubernetes/admin.conf";
     private static final String NODE_NAME = "kind";

--- a/src/main/resources/kubeadm-1.36.0.yaml
+++ b/src/main/resources/kubeadm-1.36.0.yaml
@@ -1,0 +1,80 @@
+apiServer:
+  certSANs: [{{ .CertSANs }}]
+  extraArgs:
+    - name: runtime-config
+      value: ""
+    - name: service-node-port-range
+      value: "{{ .MinNodePort }}-{{ .MaxNodePort }}"
+apiVersion: kubeadm.k8s.io/v1beta4
+clusterName: kind
+controlPlaneEndpoint: {{ .NodeIp }}:6443
+controllerManager:
+  extraArgs:
+    - name: enable-hostpath-provisioner
+      value: "true"
+kind: ClusterConfiguration
+kubernetesVersion: {{ .KubernetesVersion }}
+networking:
+  podSubnet: {{ .PodSubnet }}
+  serviceSubnet: {{ .ServiceSubnet }}
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+bootstrapTokens:
+  - token: abcdef.0123456789abcdef
+kind: InitConfiguration
+localAPIEndpoint:
+  advertiseAddress: {{ .NodeIp }}
+  bindPort: 6443
+nodeRegistration:
+  criSocket: unix:///run/containerd/containerd.sock
+  kubeletExtraArgs:
+    - name: fail-swap-on
+      value: "false"
+    - name: node-ip
+      value: {{ .NodeIp }}
+    - name: node-labels
+      value: ""
+    - name: provider-id
+      value: kind://docker/kind/kindcontainer-control-plane
+---
+apiVersion: kubeadm.k8s.io/v1beta4
+controlPlane:
+  localAPIEndpoint:
+    advertiseAddress: {{ .NodeIp }}
+    bindPort: 6443
+discovery:
+  bootstrapToken:
+    apiServerEndpoint: {{ .NodeIp }}:6443
+    token: abcdef.0123456789abcdef
+    unsafeSkipCAVerification: true
+kind: JoinConfiguration
+nodeRegistration:
+  criSocket: unix:///run/containerd/containerd.sock
+  kubeletExtraArgs:
+    - name: fail-swap-on
+      value: "false"
+    - name: node-ip
+      value: {{ .NodeIp }}
+    - name: node-labels
+      value: ""
+    - name: provider-id
+      value: kind://docker/kind/kindcontainer-control-plane
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+cgroupDriver: systemd
+cgroupRoot: /kubelet
+evictionHard:
+  imagefs.available: 0%
+  nodefs.available: 0%
+  nodefs.inodesFree: 0%
+failSwapOn: false
+imageGCHighThresholdPercent: 100
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+conntrack:
+  maxPerCore: 0
+iptables:
+  minSyncPeriod: 1s
+kind: KubeProxyConfiguration
+mode: iptables


### PR DESCRIPTION
Adds a kubeadm v1beta4 configuration template and selects it for Kubernetes 1.36.0 and newer.

This is stacked on top of the KindContainer 1.36.1 support PR so CI can exercise the new kubeadm configuration immediately with Kubernetes 1.36.1. Older Kubernetes versions continue to use the existing v1beta3 template.

The migration mirrors upstream kind's version boundary: kubeadm v1beta4 is used from Kubernetes 1.36 onward, while Kubernetes 1.37 removes v1beta3 support entirely.

Notable schema changes in v1beta4 include list-based `extraArgs` and `kubeletExtraArgs`, which are reflected in the new template.