### PR TITLE
Work around K3s pod-resources socket flake

### DIFF
--- a/src/main/java/com/dajudge/kindcontainer/K3sContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/K3sContainer.java
@@ -24,6 +24,7 @@ public class K3sContainer<SELF extends K3sContainer<SELF>> extends KubernetesWit
     private static final HashMap<String, String> TMP_FILESYSTEMS = new HashMap<String, String>() {{
         put("/run", "");
         put("/var/run", "");
+        put("/var/lib/kubelet/pod-resources", "");
     }};
     private final K3sContainerVersion version;
     private int minNodePort = 30000;


### PR DESCRIPTION
## What changed

Mount `/var/lib/kubelet/pod-resources` as tmpfs in `K3sContainer`.

## Why

K3s can occasionally fail kubelet startup with:

`failed to move temporary file to addr "/var/lib/kubelet/pod-resources/kubelet.sock": ... invalid cross-device link`

This is the same failure tracked upstream in k3s-io/k3s#4042. Keeping the pod-resources socket directory on a dedicated tmpfs avoids the overlay/filesystem boundary involved in the failing rename without moving broader K3s or kubelet state into memory.

## Impact

The change is intentionally narrow: only the kubelet pod-resources runtime socket directory is affected. Existing `/run` and `/var/run` tmpfs mounts remain unchanged.