### PR TITLE
Avoid Docker archive churn when reading K3s kubeconfig

### DIFF
--- a/src/main/java/com/dajudge/kindcontainer/K3sContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/K3sContainer.java
@@ -8,6 +8,7 @@ package com.dajudge.kindcontainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +22,7 @@ import static java.util.Arrays.asList;
 public class K3sContainer<SELF extends K3sContainer<SELF>> extends KubernetesWithKubeletContainer<SELF> {
     private static final Logger LOG = LoggerFactory.getLogger(K3sContainer.class);
     private static final int INTERNAL_API_SERVER_PORT = 6443;
+    private static final String KUBECONFIG_PATH = "/etc/rancher/k3s/k3s.yaml";
     private static final HashMap<String, String> TMP_FILESYSTEMS = new HashMap<String, String>() {{
         put("/run", "");
         put("/var/run", "");
@@ -29,6 +31,7 @@ public class K3sContainer<SELF extends K3sContainer<SELF>> extends KubernetesWit
     private int minNodePort = 30000;
     private int maxNodePort = 32767;
     private Function<List<String>, List<String>> cmdLineModifier = Function.identity();
+    private String originalKubeconfig;
 
     public K3sContainer() {
         this(latest(K3sContainerVersion.class));
@@ -50,6 +53,7 @@ public class K3sContainer<SELF extends K3sContainer<SELF>> extends KubernetesWit
 
     @Override
     public void start() {
+        originalKubeconfig = null;
         final List<String> cmdLine = cmdLineModifier.apply(new ArrayList<>(asList(
                 "server",
                 getDisabledComponentsCmdlineArg(),
@@ -96,7 +100,25 @@ public class K3sContainer<SELF extends K3sContainer<SELF>> extends KubernetesWit
         return replaceServerInKubeconfig(server, getOriginalKubeconfig());
     }
 
-    private String getOriginalKubeconfig() {
-        return copyFileFromContainer("/etc/rancher/k3s/k3s.yaml", Utils::readString);
+    private synchronized String getOriginalKubeconfig() {
+        if (originalKubeconfig != null) {
+            return originalKubeconfig;
+        }
+
+        try {
+            final ExecResult result = execInContainer("cat", KUBECONFIG_PATH);
+            if (result.getExitCode() != 0) {
+                throw new IllegalStateException(
+                        String.format("Failed to read %s: %s", KUBECONFIG_PATH, result.getStderr())
+                );
+            }
+            originalKubeconfig = result.getStdout();
+            return originalKubeconfig;
+        } catch (final IOException e) {
+            throw new IllegalStateException("Failed to read " + KUBECONFIG_PATH, e);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while reading " + KUBECONFIG_PATH, e);
+        }
     }
 }

--- a/src/test/java/com/dajudge/kindcontainer/K3sContainerTest.java
+++ b/src/test/java/com/dajudge/kindcontainer/K3sContainerTest.java
@@ -1,0 +1,42 @@
+package com.dajudge.kindcontainer;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container.ExecResult;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class K3sContainerTest {
+    private static final String KUBECONFIG_PATH = "/etc/rancher/k3s/k3s.yaml";
+    private static final String KUBECONFIG = """
+            clusters:
+            - cluster:
+                server: https://127.0.0.1:6443
+              name: default
+            """;
+
+    @Test
+    void retriesFailedKubeconfigReadAndCachesFirstSuccessfulRead() throws Exception {
+        final ExecResult failed = mock(ExecResult.class);
+        when(failed.getExitCode()).thenReturn(1);
+        when(failed.getStderr()).thenReturn("not ready");
+
+        final ExecResult succeeded = mock(ExecResult.class);
+        when(succeeded.getExitCode()).thenReturn(0);
+        when(succeeded.getStdout()).thenReturn(KUBECONFIG);
+
+        final K3sContainer<?> container = spy(new K3sContainer<>());
+        doReturn(failed, succeeded).when(container).execInContainer("cat", KUBECONFIG_PATH);
+
+        assertThrows(IllegalStateException.class, () -> container.getKubeconfig("https://localhost:6443"));
+        container.getKubeconfig("https://localhost:6443");
+        container.getKubeconfig("https://localhost:6443");
+
+        verify(container, times(2)).execInContainer("cat", KUBECONFIG_PATH);
+    }
+}


### PR DESCRIPTION
## Summary

- read `/etc/rancher/k3s/k3s.yaml` with `execInContainer("cat", ...)` instead of Testcontainers' container copy/archive API
- cache the first successful original kubeconfig read
- retry after early failed reads so startup races with kubeconfig creation do not poison the cache
- reset the cache when the container is started again

## Motivation

`KubernetesWithKubeletContainer` polls node readiness frequently during startup. For K3s, each poll creates a client and obtains the kubeconfig. The previous implementation used `copyFileFromContainer`, which exercises Docker's archive API for every poll. Docker event traces from a separate reproducer show archive operations correlating with mount/unmount activity for container volumes during K3s startup, including `/var/lib/kubelet`.

This change avoids that unnecessary archive/mount churn by using Docker exec to read the small kubeconfig file and, once available, caching it for subsequent calls. That should reduce exposure to the suspected startup race.

This is a mitigation in `kindcontainer`; it does **not** fix or claim to fix the underlying Kubernetes/kubelet `EXDEV` issue.

## Tests

- added a focused unit test verifying that a failed initial kubeconfig read is retried and that the first successful read is cached
- CI matrix validates the normal K3s integration tests