### PR TITLE
Validate K3s kubeconfig before caching

### DIFF
--- a/src/main/java/com/dajudge/kindcontainer/K3sContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/K3sContainer.java
@@ -96,15 +96,18 @@ public class K3sContainer<SELF extends K3sContainer<SELF>> extends KubernetesWit
     }
 
     @Override
-    protected String getKubeconfig(final String server) {
-        return replaceServerInKubeconfig(server, getOriginalKubeconfig());
-    }
-
-    private synchronized String getOriginalKubeconfig() {
+    protected synchronized String getKubeconfig(final String server) {
         if (originalKubeconfig != null) {
-            return originalKubeconfig;
+            return replaceServerInKubeconfig(server, originalKubeconfig);
         }
 
+        final String candidate = readOriginalKubeconfig();
+        final String kubeconfig = replaceServerInKubeconfig(server, candidate);
+        originalKubeconfig = candidate;
+        return kubeconfig;
+    }
+
+    private String readOriginalKubeconfig() {
         try {
             final ExecResult result = execInContainer("cat", KUBECONFIG_PATH);
             if (result.getExitCode() != 0) {
@@ -112,8 +115,7 @@ public class K3sContainer<SELF extends K3sContainer<SELF>> extends KubernetesWit
                         String.format("Failed to read %s: %s", KUBECONFIG_PATH, result.getStderr())
                 );
             }
-            originalKubeconfig = result.getStdout();
-            return originalKubeconfig;
+            return result.getStdout();
         } catch (final IOException e) {
             throw new IllegalStateException("Failed to read " + KUBECONFIG_PATH, e);
         } catch (final InterruptedException e) {

--- a/src/test/java/com/dajudge/kindcontainer/K3sContainerTest.java
+++ b/src/test/java/com/dajudge/kindcontainer/K3sContainerTest.java
@@ -39,4 +39,24 @@ class K3sContainerTest {
 
         verify(container, times(2)).execInContainer("cat", KUBECONFIG_PATH);
     }
+
+    @Test
+    void retriesSuccessfulButIncompleteKubeconfigRead() throws Exception {
+        final ExecResult incomplete = mock(ExecResult.class);
+        when(incomplete.getExitCode()).thenReturn(0);
+        when(incomplete.getStdout()).thenReturn("clusters: [");
+
+        final ExecResult succeeded = mock(ExecResult.class);
+        when(succeeded.getExitCode()).thenReturn(0);
+        when(succeeded.getStdout()).thenReturn(KUBECONFIG);
+
+        final K3sContainer<?> container = spy(new K3sContainer<>());
+        doReturn(incomplete, succeeded).when(container).execInContainer("cat", KUBECONFIG_PATH);
+
+        assertThrows(RuntimeException.class, () -> container.getKubeconfig("https://localhost:6443"));
+        container.getKubeconfig("https://localhost:6443");
+        container.getKubeconfig("https://localhost:6443");
+
+        verify(container, times(2)).execInContainer("cat", KUBECONFIG_PATH);
+    }
 }


### PR DESCRIPTION
## Summary

- only cache the original K3s kubeconfig after `replaceServerInKubeconfig(...)` has parsed and transformed it successfully
- retry reads when `cat` exits successfully but returns incomplete or malformed YAML
- add a regression test covering the successful-but-incomplete read case

## Motivation

The previous caching change avoided repeated Docker archive API calls during K3s startup, but cached stdout immediately after a successful `cat`. During startup, a read could in principle observe an empty or partially written kubeconfig while still returning exit code 0. That invalid value would then be cached before parsing, causing every subsequent readiness poll to reuse the same broken kubeconfig until startup timed out.

This change keeps the archive-avoidance mitigation intact while moving the cache assignment after the existing kubeconfig parser/transformer succeeds. A failed parse therefore leaves the cache empty and the next readiness poll re-reads the file.

This is still a `kindcontainer` mitigation around startup behavior; it does not address the underlying Kubernetes/kubelet `EXDEV` issue.

## Tests

- existing test still verifies non-zero read failures are retried and the first successful valid read is cached
- new test verifies an exit-0 malformed/partial kubeconfig is not cached and a later valid read succeeds
