### PR TITLE
Upload Gradle test reports on CI failure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,3 +44,13 @@ jobs:
         env:
           CONTAINER_FILTER: ${{ matrix.version }}
         run: ./gradlew build
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ matrix.version }}
+          path: |
+            build/reports/tests/test/
+            build/test-results/test/
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
## Summary
- upload Gradle HTML and XML test reports whenever a matrix build fails
- keep the artifacts for 7 days
- name artifacts after the failing matrix entry so failures are easy to identify and inspect

This makes integration-test failures diagnosable without scraping long GitHub Actions logs.