### PR TITLE
Log etcd and API server output on startup failure

### DIFF
--- a/src/main/java/com/dajudge/kindcontainer/ApiServerContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/ApiServerContainer.java
@@ -144,10 +144,28 @@ public class ApiServerContainer<T extends ApiServerContainer<T>> extends Kuberne
     @Override
     protected void containerIsStarting(final InspectContainerResponse containerInfo) {
         etcd = new EtcdContainer(etcdImage, etcdCa, containerInfo.getId());
-        etcd.start();
-        waitForApiServer();
-        waitForDefaultNamespace();
-        super.containerIsStarting(containerInfo);
+        try {
+            etcd.start();
+            waitForApiServer();
+            waitForDefaultNamespace();
+            super.containerIsStarting(containerInfo);
+        } catch (final RuntimeException e) {
+            logStartupDiagnostics();
+            throw e;
+        }
+    }
+
+    private void logStartupDiagnostics() {
+        try {
+            LOG.error("etcd logs:\n{}", etcd.getLogs());
+        } catch (final RuntimeException e) {
+            LOG.error("Failed to retrieve etcd logs", e);
+        }
+        try {
+            LOG.error("API server logs:\n{}", getLogs());
+        } catch (final RuntimeException e) {
+            LOG.error("Failed to retrieve API server logs", e);
+        }
     }
 
     private void waitForDefaultNamespace() {


### PR DESCRIPTION
## Summary
- capture etcd container logs when `ApiServerContainer` startup fails
- capture API server logs alongside them
- preserve the original startup exception after diagnostics are emitted

This is intended to make intermittent control-plane/etcd startup failures diagnosable from CI logs.