### PR TITLE
Increase default namespace startup timeout

### DIFF
--- a/src/main/java/com/dajudge/kindcontainer/ApiServerContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/ApiServerContainer.java
@@ -151,7 +151,7 @@ public class ApiServerContainer<T extends ApiServerContainer<T>> extends Kuberne
     }
 
     private void waitForDefaultNamespace() {
-        await().timeout(10, SECONDS)
+        await().timeout(60, SECONDS)
                 .until(() -> client().v1().namespaces().find("default"), Optional::isPresent);
     }
 


### PR DESCRIPTION
## Summary
- increase the post-API-server wait for the Kubernetes `default` namespace from 10 seconds to 60 seconds
- keep the existing API server readiness timeout unchanged

The previous 10-second window is unnecessarily brittle on loaded CI runners while the control plane is finishing bootstrap.