### PR TITLE
Update etcd sidecar to 3.7.1

### DIFF
--- a/src/main/java/com/dajudge/kindcontainer/ApiServerContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/ApiServerContainer.java
@@ -45,7 +45,7 @@ public class ApiServerContainer<T extends ApiServerContainer<T>> extends Kuberne
     private static final int INTERNAL_API_SERVER_PORT = 6443;
     private final CertAuthority etcdCa = new CertAuthority(System::currentTimeMillis, "CN=etcd CA");
     private final CertAuthority apiServerCa = new CertAuthority(System::currentTimeMillis, "CN=API Server CA");
-    private DockerImageName etcdImage = DockerImageName.parse("registry.k8s.io/etcd:3.7.1-0");
+    private DockerImageName etcdImage = DockerImageName.parse("gcr.io/etcd-development/etcd:v3.7.1");
     private final KeyStoreWrapper apiServerKeyPair = apiServerCa.newKeyPair("O=system:masters,CN=kubernetes-admin", asList(
             new GeneralName(GeneralName.iPAddress, Utils.resolve(getHost())),
             new GeneralName(GeneralName.dNSName, "localhost"),

--- a/src/main/java/com/dajudge/kindcontainer/ApiServerContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/ApiServerContainer.java
@@ -45,7 +45,7 @@ public class ApiServerContainer<T extends ApiServerContainer<T>> extends Kuberne
     private static final int INTERNAL_API_SERVER_PORT = 6443;
     private final CertAuthority etcdCa = new CertAuthority(System::currentTimeMillis, "CN=etcd CA");
     private final CertAuthority apiServerCa = new CertAuthority(System::currentTimeMillis, "CN=API Server CA");
-    private DockerImageName etcdImage = DockerImageName.parse("registry.k8s.io/etcd:3.5.12-0");
+    private DockerImageName etcdImage = DockerImageName.parse("registry.k8s.io/etcd:3.7.1-0");
     private final KeyStoreWrapper apiServerKeyPair = apiServerCa.newKeyPair("O=system:masters,CN=kubernetes-admin", asList(
             new GeneralName(GeneralName.iPAddress, Utils.resolve(getHost())),
             new GeneralName(GeneralName.dNSName, "localhost"),


### PR DESCRIPTION
## Summary
- update the default etcd sidecar from Kubernetes' older `registry.k8s.io/etcd:3.5.12-0` image to upstream etcd `v3.7.1`
- use the upstream primary container registry documented by etcd

The full Kubernetes matrix should validate compatibility, especially with the oldest supported API server versions.