### PR TITLE
Update nginx sidecar to 1.30.4

### DIFF
--- a/src/main/java/com/dajudge/kindcontainer/KubernetesContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/KubernetesContainer.java
@@ -234,7 +234,7 @@ public abstract class KubernetesContainer<T extends KubernetesContainer<T>> exte
      * @param serviceAccountNamespace the namespace of the service account
      * @param serviceAccountName      the name of the service account
      * @param autoCreateToken         if <code>true</code>, the service account will be created if it doesn't exist
-     * @return <code>this</code>
+     * @return the kubeconfig
      */
     public String getServiceAccountKubeconfig(
             final String serviceAccountNamespace,

--- a/src/main/java/com/dajudge/kindcontainer/KubernetesContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/KubernetesContainer.java
@@ -42,7 +42,7 @@ public abstract class KubernetesContainer<T extends KubernetesContainer<T>> exte
     private final LazyContainer<Helm3Container<?>> helm3 = Helm3Container.lazy(helm3Image::get, this::getContainerId, this::getInternalKubeconfig);
     private final AtomicReference<DockerImageName> kubectlImage = new AtomicReference<>(latest(K3sContainerVersion.class).toImageSpec().getImage());
     private final LazyContainer<KubectlContainer<?, T>> kubectl = KubectlContainer.lazy(kubectlImage::get, this::getContainerId, this::getInternalKubeconfig, self());
-    private final AtomicReference<DockerImageName> nginxImage = new AtomicReference<>(DockerImageName.parse("nginx:1.23.3"));
+    private final AtomicReference<DockerImageName> nginxImage = new AtomicReference<>(DockerImageName.parse("nginx:1.30.4"));
     private final AtomicReference<DockerImageName> opensshServerImage = new AtomicReference<>(DockerImageName.parse("linuxserver/openssh-server:9.0_p1-r2-ls99"));
     private final AdmissionControllerManager admissionControllerManager = new AdmissionControllerManager(this, 10000, nginxImage::get, opensshServerImage::get);
     private boolean postStartupExecutionsDone;
@@ -234,7 +234,7 @@ public abstract class KubernetesContainer<T extends KubernetesContainer<T>> exte
      * @param serviceAccountNamespace the namespace of the service account
      * @param serviceAccountName      the name of the service account
      * @param autoCreateToken         if <code>true</code>, the service account will be created if it doesn't exist
-     * @return the kubeconfig
+     * @return <code>this</code>
      */
     public String getServiceAccountKubeconfig(
             final String serviceAccountNamespace,


### PR DESCRIPTION
## Summary
- update the default nginx sidecar from 1.23.3 to the current stable nginx release, 1.30.4
- keep the version pinned rather than using a floating tag
