### PR TITLE
Update OpenSSH sidecar to 10.3_p1-r1-ls235

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ by default. These are the images used by Kindcontainer if you don't override the
 |    Fluent API `helm`    |          `alpine/helm`           |              `3.14.0`              |
 |  Fluent API `kubectl`   |        `bitnami/kubectl`         |       `1.21.9-debian-10-r10`       |
 |    Webhooks `nginx`     |             `nginx`              |              `1.23.3`              |
-| Webhooks OpenSSH Server |   `linuxserver/openssh-server`   |          `9.0_p1-r2-ls99`          |         
+| Webhooks OpenSSH Server |   `linuxserver/openssh-server`   |        `10.3_p1-r1-ls235`          |         
 
 ### Kubernetes images
 
@@ -263,7 +263,7 @@ are being used to start those support containers use the `withNginxImage()` and 
 ```java
 ApiServerContainer<?> container = new ApiServerContainer<>()
         .withNginxImage(DockerImageName.parse("my-registry/nginx:1.23.3"))
-        .withOpensshServerImage(DockerImageName.parse("my-registry/openssh-server:9.0_p1-r2-ls99"));
+        .withOpensshServerImage(DockerImageName.parse("my-registry/openssh-server:10.3_p1-r1-ls235"));
 ```
 
 ## Testing admission webhooks

--- a/src/main/java/com/dajudge/kindcontainer/KubernetesContainer.java
+++ b/src/main/java/com/dajudge/kindcontainer/KubernetesContainer.java
@@ -43,7 +43,7 @@ public abstract class KubernetesContainer<T extends KubernetesContainer<T>> exte
     private final AtomicReference<DockerImageName> kubectlImage = new AtomicReference<>(latest(K3sContainerVersion.class).toImageSpec().getImage());
     private final LazyContainer<KubectlContainer<?, T>> kubectl = KubectlContainer.lazy(kubectlImage::get, this::getContainerId, this::getInternalKubeconfig, self());
     private final AtomicReference<DockerImageName> nginxImage = new AtomicReference<>(DockerImageName.parse("nginx:1.30.4"));
-    private final AtomicReference<DockerImageName> opensshServerImage = new AtomicReference<>(DockerImageName.parse("linuxserver/openssh-server:9.0_p1-r2-ls99"));
+    private final AtomicReference<DockerImageName> opensshServerImage = new AtomicReference<>(DockerImageName.parse("linuxserver/openssh-server:10.3_p1-r1-ls235"));
     private final AdmissionControllerManager admissionControllerManager = new AdmissionControllerManager(this, 10000, nginxImage::get, opensshServerImage::get);
     private boolean postStartupExecutionsDone;
     private HashSet<Integer> userExposedPorts = new HashSet<>();

--- a/src/main/java/com/dajudge/kindcontainer/webhook/AdmissionControllerManager.java
+++ b/src/main/java/com/dajudge/kindcontainer/webhook/AdmissionControllerManager.java
@@ -64,7 +64,7 @@ public class AdmissionControllerManager {
                 .withEnv("PASSWORD_ACCESS", "true")
                 .withEnv("USER_NAME", "t0ny")
                 .withEnv("USER_PASSWORD", "p3pp3r")
-                .withCopyToContainer(Transferable.of(sshdConfig), "/etc/ssh/sshd_config");
+                .withCopyToContainer(Transferable.of(sshdConfig), "/config/sshd/sshd_config.d/kindcontainer.conf");
         final String nginxConfig = nginxConfig();
         LOG.debug("Admission controller reverse proxy nginx config: {}", nginxConfig);
         nginx = new GenericContainer<>(nginxImage.get())


### PR DESCRIPTION
## Summary
- update the default LinuxServer OpenSSH sidecar from 9.0_p1-r2-ls99 to 10.3_p1-r1-ls235
- keep the version pinned rather than using a floating tag
