### PR TITLE
Document sidecar update hygiene for releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # AGENTS.md
 
+## Release hygiene
+
+Before preparing a new release, **strongly prefer checking every pinned sidecar/default container image against its upstream current stable release and updating stale images in dedicated PRs**. Do not silently carry obsolete sidecar versions into a new release when a supported update is available.
+
+Keep image versions pinned for reproducibility rather than switching defaults to floating `latest` tags. Treat updates that imply an API or behavior migration (for example, a new major version) as explicit migration work instead of routine hygiene, and let the full CI matrix validate compatibility before merging.
+
 ## Release workflow
 
 Releases are cut from `master` using tags named `release/X.Y.Z` and GitHub releases named `vX.Y.Z`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ Before preparing a new release, **strongly prefer checking every pinned sidecar/
 
 Keep image versions pinned for reproducibility rather than switching defaults to floating `latest` tags. Treat updates that imply an API or behavior migration (for example, a new major version) as explicit migration work instead of routine hygiene, and let the full CI matrix validate compatibility before merging.
 
+Whenever a default or pinned container image changes, **update all documentation of that default in the same PR**, including default-image tables, examples, mirror/pre-pull guidance, and allowlist references. The documented image set must stay consistent with what an unconfigured container actually pulls.
+
 ## Release workflow
 
 Releases are cut from `master` using tags named `release/X.Y.Z` and GitHub releases named `vX.Y.Z`.


### PR DESCRIPTION
## Summary
- strongly prefer checking every pinned sidecar/default image against its upstream current stable release before cutting a new release
- keep defaults pinned for reproducibility rather than using floating `latest` tags
- treat major-version jumps as explicit migrations and require the full CI matrix before merging
