### PR TITLE
Add macOS smoke tests for latest container versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -106,12 +106,26 @@ jobs:
           distribution: 'temurin'
       - name: Set up Docker with Colima
         run: |
-          brew install docker colima
-          colima start --network-address --cpu 4 --memory 8
+          brew install docker colima qemu
+          colima start --vm-type=qemu --network-address --cpu 4 --memory 8
           echo "DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock" >> $GITHUB_ENV
           echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> $GITHUB_ENV
           echo "TESTCONTAINERS_HOST_OVERRIDE=$(colima ls -j | jq -r '.address')" >> $GITHUB_ENV
           docker info
+      - name: Capture Colima diagnostics
+        if: failure()
+        run: |
+          {
+            echo '=== colima status ==='
+            colima status || true
+            echo '=== colima list ==='
+            colima list || true
+            echo '=== lima host agent stderr ==='
+            cat "$HOME/.colima/_lima/colima/ha.stderr.log" 2>/dev/null || true
+            echo '=== lima serial logs ==='
+            cat "$HOME"/.colima/_lima/colima/serial*.log 2>/dev/null || true
+          } > macos-smoke-diagnostics.txt 2>&1
+          cat macos-smoke-diagnostics.txt
       - name: Run smoke tests
         env:
           CONTAINER_FILTER: ${{ matrix.version }}
@@ -124,5 +138,13 @@ jobs:
           path: |
             build/reports/tests/test/
             build/test-results/test/
+          if-no-files-found: ignore
+          retention-days: 7
+      - name: Upload macOS smoke diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-smoke-diagnostics-${{ matrix.version }}
+          path: macos-smoke-diagnostics.txt
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
           retention-days: 7
 
   macos-smoke:
-    runs-on: macos-15
+    runs-on: macos-15-intel
     needs: matrix
     strategy:
       fail-fast: false
@@ -106,8 +106,8 @@ jobs:
           distribution: 'temurin'
       - name: Set up Docker with Colima
         run: |
-          brew install docker colima
-          colima start --vm-type=vz --network-address --cpu 4 --memory 8
+          brew install docker colima qemu
+          colima start --vm-type=qemu --network-address --cpu 4 --memory 8
           echo "DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock" >> $GITHUB_ENV
           echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> $GITHUB_ENV
           echo "TESTCONTAINERS_HOST_OVERRIDE=$(colima ls -j | jq -r '.address')" >> $GITHUB_ENV

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,13 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      smoke-matrix: ${{ steps.set-matrix.outputs.smoke-matrix }}
     steps:
       - uses: actions/checkout@v4
       - id: set-matrix
         run: |
           matrix=$( cat k8s-versions.json | jq '{version: [keys[] as $k | .[$k].versions[] | .k8s as $v | "\($k) \($v)"]}' -c )
+          smoke_matrix=$( cat k8s-versions.json | jq '{version: [to_entries[] | "\(.key) \(.value.versions[-1].k8s)"]}' -c )
           echo $matrix
+          echo $smoke_matrix
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
+          echo "smoke-matrix=$smoke_matrix" >> $GITHUB_OUTPUT
 
   check-matrix:
     runs-on: ubuntu-latest
@@ -25,8 +29,11 @@ jobs:
       - name: Check matrix definition
         run: |
           matrix='${{ needs.matrix.outputs.matrix }}'
+          smoke_matrix='${{ needs.matrix.outputs.smoke-matrix }}'
           echo $matrix
           echo $matrix | jq .
+          echo $smoke_matrix
+          echo $smoke_matrix | jq .
 
   build:
     runs-on: ubuntu-latest
@@ -82,4 +89,40 @@ jobs:
         with:
           name: runner-diagnostics-${{ strategy.job-index }}
           path: runner-diagnostics.txt
+          retention-days: 7
+
+  macos-smoke:
+    runs-on: macos-latest
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.matrix.outputs.smoke-matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Set up Docker with Colima
+        run: |
+          brew install docker colima
+          colima start --network-address --cpu 4 --memory 8
+          echo "DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock" >> $GITHUB_ENV
+          echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> $GITHUB_ENV
+          echo "TESTCONTAINERS_HOST_OVERRIDE=$(colima ls -j | jq -r '.address')" >> $GITHUB_ENV
+          docker info
+      - name: Run smoke tests
+        env:
+          CONTAINER_FILTER: ${{ matrix.version }}
+        run: ./gradlew test
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-test-reports-${{ matrix.version }}
+          path: |
+            build/reports/tests/test/
+            build/test-results/test/
+          if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
           retention-days: 7
 
   macos-smoke:
-    runs-on: macos-15-intel
+    runs-on: macos-15
     needs: matrix
     strategy:
       fail-fast: false
@@ -107,17 +107,16 @@ jobs:
       - name: Set up Docker with Colima
         run: |
           brew install docker colima qemu
-          colima start --vm-type=qemu --network-address --cpu 4 --memory 8
+          colima start --vm-type=qemu --cpu 4 --memory 8
           echo "DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock" >> $GITHUB_ENV
           echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> $GITHUB_ENV
-          echo "TESTCONTAINERS_HOST_OVERRIDE=$(colima ls -j | jq -r '.address')" >> $GITHUB_ENV
+          echo "TESTCONTAINERS_HOST_OVERRIDE=127.0.0.1" >> $GITHUB_ENV
           docker info
       - name: Verify Colima networking
         run: |
           set -euo pipefail
-          colima_address=$(colima ls -j | jq -r '.address')
           docker run --detach --rm --name colima-network-preflight -p 18080:80 nginx:alpine
-          curl --fail --retry 10 --retry-connrefused --retry-delay 1 "http://${colima_address}:18080"
+          curl --fail --retry 10 --retry-connrefused --retry-delay 1 "http://127.0.0.1:18080"
           docker rm -f colima-network-preflight
       - name: Run smoke tests
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
           retention-days: 7
 
   macos-smoke:
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: matrix
     strategy:
       fail-fast: false
@@ -106,12 +106,23 @@ jobs:
           distribution: 'temurin'
       - name: Set up Docker with Colima
         run: |
-          brew install docker colima qemu
-          colima start --vm-type=qemu --network-address --cpu 4 --memory 8
+          brew install docker colima
+          colima start --vm-type=vz --network-address --cpu 4 --memory 8
           echo "DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock" >> $GITHUB_ENV
           echo "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock" >> $GITHUB_ENV
           echo "TESTCONTAINERS_HOST_OVERRIDE=$(colima ls -j | jq -r '.address')" >> $GITHUB_ENV
           docker info
+      - name: Verify Colima networking
+        run: |
+          set -euo pipefail
+          colima_address=$(colima ls -j | jq -r '.address')
+          docker run --detach --rm --name colima-network-preflight -p 18080:80 nginx:alpine
+          curl --fail --retry 10 --retry-connrefused --retry-delay 1 "http://${colima_address}:18080"
+          docker rm -f colima-network-preflight
+      - name: Run smoke tests
+        env:
+          CONTAINER_FILTER: ${{ matrix.version }}
+        run: ./gradlew test
       - name: Capture Colima diagnostics
         if: failure()
         run: |
@@ -120,16 +131,16 @@ jobs:
             colima status || true
             echo '=== colima list ==='
             colima list || true
+            echo '=== docker info ==='
+            docker info || true
+            echo '=== docker containers ==='
+            docker ps -a || true
             echo '=== lima host agent stderr ==='
             cat "$HOME/.colima/_lima/colima/ha.stderr.log" 2>/dev/null || true
             echo '=== lima serial logs ==='
             cat "$HOME"/.colima/_lima/colima/serial*.log 2>/dev/null || true
           } > macos-smoke-diagnostics.txt 2>&1
           cat macos-smoke-diagnostics.txt
-      - name: Run smoke tests
-        env:
-          CONTAINER_FILTER: ${{ matrix.version }}
-        run: ./gradlew test
       - name: Upload test reports on failure
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Adds lightweight macOS smoke coverage while keeping the full Kubernetes/container matrix on Ubuntu.

The new `macos-smoke` job:

- derives the latest declared version of each container flavor from `k8s-versions.json`,
- runs one smoke job each for `KindContainer`, `K3sContainer`, and `ApiServerContainer`,
- starts Docker via Colima on the GitHub-hosted macOS runner,
- configures the documented Testcontainers Colima socket/host overrides,
- runs the existing test suite filtered to the selected flavor/version,
- uploads test reports on failure.

This intentionally does not add Windows CI yet. GitHub-hosted Windows runners do not provide a comparably clean Docker environment for meaningful Testcontainers smoke coverage, so a build-only check would give false confidence rather than exercising the actual runtime path.

Supersedes the implementation approach in #279 without reviving its stale runner/action setup.